### PR TITLE
Fixed a documentation error when installing the Maruku gem

### DIFF
--- a/lib/maruku.rb
+++ b/lib/maruku.rb
@@ -20,7 +20,6 @@
 
 require 'rexml/document'
 
-# :include:MaRuKu.txt
 module MaRuKu
 
 	module In


### PR DESCRIPTION
Fixed a documentation error when installing the Maruku gem

---

Couldn't find file to include 'MaRuKu.txt' from lib/maruku.rb
