### PR TITLE
Fixed embedding Radiant link

### DIFF
--- a/docs/website/src/embedding/radiant.page
+++ b/docs/website/src/embedding/radiant.page
@@ -6,7 +6,7 @@ title: "Embedding Maruku in Radiant"
 
 [Bjorn Michelsen] created a [Radiant] extension for Maruku:
 
-<http://github.com/michelsen/radiant_maruku>
+<http://github.com/bmichelsen/radiant_maruku>
 
 
 [Bjorn Michelsen]: http://www.bmichelsen.no


### PR DESCRIPTION
I broke the link on http://maruku.rubyforge.org/embedding/radiant.html because I change my username on github. This comit fixes the issue.
