### PR TITLE
Add folder 'data' to gem package.

### DIFF
--- a/maruku.gemspec
+++ b/maruku.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb'] + Dir['lib/*.rb'] + 
 	Dir['docs/*.md'] +	Dir['docs/*.html'] +
 	Dir['spec/**/*.rb'] + Dir['spec/**/*.md'] +
-          Dir['bin/*'] + ['Rakefile']
+          Dir['data/*'] + Dir['bin/*'] + ['Rakefile']
 
   s.bindir = 'bin'
   s.executables = ['maruku','marutex']


### PR DESCRIPTION
I don't know why folder 'data' is not in the gem package, but this folder seems to be necessary if one wants to install this version of maruku and make it work.

Signed-off-by: Li Yao hnkfliyao@gmail.com
