### PR TITLE
Fix Math Link to Documentation on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Maruku implements:
 * All the improvements in PHP Markdown Extra.
 * A new meta-data syntax.
 
-Read more about [Maruku's Markdown syntax](http://rdoc.info/github/bhollis/maruku/master/file/docs/markdown_syntax.md). It also supports [inline math](http://rdoc.info/github/bhollis/maruku/master/file/docs/math.m). [Maruku docs](http://rdoc.info/github/bhollis/maruku/master/).
+Read more about [Maruku's Markdown syntax](http://rdoc.info/github/bhollis/maruku/master/file/docs/markdown_syntax.md). It also supports [inline math](http://rdoc.info/github/bhollis/maruku/file/docs/math.md). [Maruku docs](http://rdoc.info/github/bhollis/maruku/master/).
 
 News about Maruku is posted at [http://benhollis.net/blog/category/maruku/](http://benhollis.net/blog/category/maruku/)
 


### PR DESCRIPTION
Simple README.md fix to point to the Math link.  I love your gem, and I noticed it as I was looking through the README, so I thought that I'd help. 
