### PR TITLE
Correctly interpret and process nested lists

### DIFF
--- a/lib/maruku/input/mdline.rb
+++ b/lib/maruku/input/mdline.rb
@@ -51,8 +51,8 @@ module MaRuKu
       return :header3        if self =~ /\A(#)+\s*\S+/
       # at least three asterisks/hyphens/underscores on a line, and only whitespace
       return :hrule          if self =~ /\A(\s*[\*\-_]\s*){3,}\z/
-      return :ulist          if self =~ /\A([ ]{0,3}|\t)([\*\-\+])\s+.*/
-      return :olist          if self =~ /\A([ ]{0,3}|\t)\d+\.\s+.*/
+      return :ulist          if self =~ /\A[ ]{0,3}([\*\-\+])\s+.*/
+      return :olist          if self =~ /\A[ ]{0,3}\d+\.\s+.*/
       return :code           if number_of_leading_spaces >= 4
       return :quote          if self =~ /\A>/
       return :ald            if self =~ AttributeDefinitionList

--- a/lib/maruku/input/parse_block.rb
+++ b/lib/maruku/input/parse_block.rb
@@ -313,9 +313,15 @@ module MaRuKu; module In; module Markdown; module BlockLevelParser
     lines, want_my_paragraph =
       read_indented_content(src, indentation, [], item_type, ial_offset)
 
+    # in case there is a second line and this line starts a new list, format it.
+    if lines.length>0 and [:ulist, :olist].include?((MaRuKu::MDLine.new(lines[0])).md_type) then
+      lines.unshift("")
+    end
+
     # add first line
     # Strip first '*', '-', '+' from first line
-    stripped = first[indentation, first.size - 1]
+    first_changed = first.gsub(/([^\t]*)(\t)/) { $1 + " " * (TAB_SIZE - $1.length % TAB_SIZE) }
+    stripped = first_changed[indentation, first_changed.size - 1]
     lines.unshift stripped
 
     src2 = LineSource.new(lines, src, parent_offset)

--- a/lib/maruku/string_utils.rb
+++ b/lib/maruku/string_utils.rb
@@ -57,21 +57,9 @@ module MaRuKu
     # @param s [String]
     # @return [Fixnum]
     def spaces_before_first_char(s)
+      sd=s.gsub(/([^\t]*)(\t)/) { $1 + " " * (TAB_SIZE - $1.length % TAB_SIZE) }
       match =
-        case s.md_type
-        when :ulist
-          # whitespace, followed by ('*'|'+'|'-') followed by
-          # more whitespace, followed by an optional IAL, followed
-          # by yet more whitespace
-          s[/^\s*(\*|\+|\-)\s*(\{[:#\.].*?\})?\s*/]
-        when :olist
-          # whitespace, followed by a number, followed by a period,
-          # more whitespace, an optional IAL, and more whitespace
-          s[/^\s*\d+\.\s*(\{[:#\.].*?\})?\s*/]
-        else
-          tell_user "BUG (my bad): '#{s}' is not a list"
-          ''
-        end
+          sd[/^\s*(\*|\+|\-|\d+.)\s*(\{[:#\.].*?\})?\s*/]
       f = /\{(.*?)\}/.match(match)
       ial = f[1] if f
       [match.length, ial]

--- a/spec/block_docs/code4.md
+++ b/spec/block_docs/code4.md
@@ -1,0 +1,78 @@
+Codes which look like lists
+*** Parameters: ***
+{}
+*** Markdown input: ***
+
+This is code (4 spaces):
+
+    * Code
+      * Code (again)
+
+This is also code
+
+    * Code
+	* Code (again)
+
+This is code (1 tab):
+
+	* Code
+		* Code (again)
+
+
+*** Output of inspect ***
+md_el(:document,[
+	md_par(["This is code (4 spaces):"]),
+	md_el(:code,[],{:raw_code=>"* Code
+  * Code (again)", :lang=>nil},[]),
+	md_par(["This is also code"]),
+	md_el(:code,[],{:raw_code=>"* Code
+* Code (again)", :lang=>nil},[]),
+	md_par(["This is code (1 tab):"]),
+	md_el(:code,[],{:raw_code=>"* Code
+	* Code (again)", :lang=>nil},[])
+],{},[])
+*** Output of to_html ***
+<p>This is code (4 spaces):</p>
+
+<pre><code>* Code
+  * Code (again)</code></pre>
+
+<p>This is also code</p>
+
+<pre><code>* Code
+* Code (again)</code></pre>
+
+<p>This is code (1 tab):</p>
+
+<pre><code>* Code
+	* Code (again)</code></pre>
+*** Output of to_latex ***
+This is code (4 spaces):
+
+\begin{verbatim}* Code
+  * Code (again)\end{verbatim}
+This is also code
+
+\begin{verbatim}* Code
+* Code (again)\end{verbatim}
+This is code (1 tab):
+
+\begin{verbatim}* Code
+	* Code (again)\end{verbatim}
+*** Output of to_md ***
+This is code (4 spaces):
+
+     * Code
+       * Code (again)
+
+This is also code
+
+     * Code
+     * Code (again)
+
+This is code (1 tab):
+
+     * Code
+         * Code (again)
+*** Output of to_s ***
+This is code (4 spaces):This is also codeThis is code (1 tab):


### PR DESCRIPTION
Nested lists must not interfer with indentation.

this patch fixes #106 
