### PR TITLE
Fixes a fatal error related to footnote rendering

### DIFF
--- a/lib/maruku/output/to_html.rb
+++ b/lib/maruku/output/to_html.rb
@@ -216,7 +216,7 @@ module MaRuKu::Out::HTML
 
     # render footnotes
     unless @doc.footnotes_order.empty?
-      body << render_footnotes(@doc)
+      body << render_footnotes
     end
 
     # When we are rendering a whole document, we add a signature


### PR DESCRIPTION
A method call was being made to render_footnotes() with to many parameters
